### PR TITLE
Improve initial report handling

### DIFF
--- a/src/components/common/Sidebar/Sidebar.jsx
+++ b/src/components/common/Sidebar/Sidebar.jsx
@@ -11,18 +11,18 @@ function Sidebar({ sidebarPosition = "left" }) {
     const [mobileOpen, setMobileOpen] = useState(false);
 
     const navigate = useNavigate();
-    const user = useSelector((state) => state.data.auth.user);
+    const userID = useSelector((state) => state.data.auth.userID);
     const [logoutApi] = useLogoutMutation();
 
     const handleLogout = () => {
-        logoutApi(user.id)
+        logoutApi(userID)
             .unwrap()
             .then(() => navigate('/'))
             .catch(() => navigate('/'));
     };
 
     const handleNavigation = (path) => {
-        navigate(`/dashboard/${user?.id}/${path}`);
+        navigate(`/dashboard/${userID}/${path}`);
         setMobileOpen(false);
     };
 

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -1,8 +1,0 @@
-// src/config/api.js
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
-
-export {
-    API_BASE_URL,
-    API_BASE_URL as API_URL,
-    // Add other constants if needed
-}

--- a/src/constants/initial-reports.js
+++ b/src/constants/initial-reports.js
@@ -500,7 +500,7 @@ const PATIENT_INFO = [
                         id: "currentlyWorking",
                         label: "Are you currently working?",
                         type: "radio",
-                        options: ["None", "YES", "NO"]
+                        options: ["none", "yes", "no"]
                     },
                     {
                         id: "workTimes",

--- a/src/constants/initial-reports.js
+++ b/src/constants/initial-reports.js
@@ -460,28 +460,28 @@ const PATIENT_INFO = [
                         id: "mentalWork",
                         label: "Mental work level",
                         type: "radio",
-                        options: ["Heavy", "Moderate", "Light"]
+                        options: ["None", "Heavy", "Moderate", "Light"]
                     },
                     { id: "mentalWorkHours", label: "Mental work hours/day", type: "text", placeholder: "8" },
                     {
                         id: "physicalWork",
                         label: "Physical work level",
                         type: "radio",
-                        options: ["Heavy", "Moderate", "Light"]
+                        options: ["None", "Heavy", "Moderate", "Light"]
                     },
                     { id: "physicalWorkHours", label: "Physical work hours/day", type: "text", placeholder: "4" },
                     {
                         id: "exercise",
                         label: "Exercise level",
                         type: "radio",
-                        options: ["Heavy", "Moderate", "Light"]
+                        options: ["None", "Heavy", "Moderate", "Light"]
                     },
                     { id: "exerciseHours", label: "Exercise hours/day", type: "text", placeholder: "1" },
                     {
                         id: "smokingStatus",
                         label: "Smoking status",
                         type: "radio",
-                        options: ["Current", "Previous"]
+                        options: ["None", "Current", "Previous"]
                     },
                     { id: "packsPerDay", label: "Packs per day", type: "text", placeholder: "0" },
                     { id: "smokingYears", label: "Years smoking", type: "text", placeholder: "0" },
@@ -500,7 +500,7 @@ const PATIENT_INFO = [
                         id: "currentlyWorking",
                         label: "Are you currently working?",
                         type: "radio",
-                        options: ["YES", "NO"]
+                        options: ["None", "YES", "NO"]
                     },
                     {
                         id: "workTimes",

--- a/src/constants/initial-reports.js
+++ b/src/constants/initial-reports.js
@@ -9,7 +9,7 @@ const PATIENT_INFO = [
                 type: "group",
                 fields: [
                     { id: "firstName", label: "First", type: "text", placeholder: "John" },
-                    { id: "middleName", label: "Middle", type: "text", placeholder: "A." },
+                    { id: "middleName", label: "Middle (Optional)", type: "text", placeholder: "A." },
                     { id: "lastName", label: "Last", type: "text", placeholder: "Doe" },
                     { id: "ssn", label: "SSN", type: "text", placeholder: "123-45-6789" }
                 ]
@@ -20,10 +20,30 @@ const PATIENT_INFO = [
                 type: "group",
                 fields: [
                     {
-                        id: "dob",
-                        label: "Date of Birth",
-                        type: "date",
-                        extra_info: "Select your birth date"
+                        id: "daysOfBirth",
+                        label: "Days of Birth",
+                        type: "radio",
+                        options: Array.from({ length: 31 }, (_, i) => (i + 1).toString()),
+                        placeholder: "1",
+                        extra_info: "Enter the day of the month you were born (1-31)."
+                    },
+                    {
+                        id: "monthOfBirth",
+                        label: "Month of Birth",
+                        type: "radio",
+                        options: [
+                            "January", "February", "March", "April", "May", "June",
+                            "July", "August", "September", "October", "November", "December"
+                        ],
+                        placeholder: "January",
+                        extra_info: "Enter the month you were born (e.g., January, February, etc.)."
+                    },
+                    {
+                        id: "yearOfBirth",
+                        label: "Year of Birth",
+                        type: "text",
+                        placeholder: "1990",
+                        extra_info: "Enter the year you were born (e.g., 1990)."
                     },
                     {
                         id: "age",

--- a/src/constants/initial-reports.js
+++ b/src/constants/initial-reports.js
@@ -147,16 +147,6 @@ const PATIENT_INFO = [
         title: "Accident & Insurance Details",
         questions: [
             {
-                id: "mainComplaints",
-                label: "What are your main problems (complaints / pains)?",
-                type: "textarea"
-            },
-            {
-                id: "previousHealthcare",
-                label: "What other health care have you received for this problem(s)?",
-                type: "textarea"
-            },
-            {
                 id: "accidentDetails",
                 label: "Accident or Illness Details",
                 type: "group",
@@ -338,6 +328,16 @@ const PATIENT_INFO = [
                 type: "textarea",
                 extra_info:
                     "Include when your symptoms began, how they have changed, and any previous treatments."
+            },
+            {
+                id: "mainComplaints",
+                label: "What are your main problems (complaints / pains)?",
+                type: "textarea"
+            },
+            {
+                id: "previousHealthcare",
+                label: "What other health care have you received for this problem(s)?",
+                type: "textarea"
             }
         ]
     },

--- a/src/constants/initial-reports.js
+++ b/src/constants/initial-reports.js
@@ -160,14 +160,14 @@ const PATIENT_INFO = [
                     {
                         id: "accidentDate",
                         label: "Date of Accident / Beginning of Illness",
-                        type: "text",
-                        placeholder: "08/15/2025",
-                        extra_info: "Use MM/DD/YYYY format."
+                        type: "date",
+                        placeholder: "2025/08/15",
+                        extra_info: "Use YYYY/MM/DD format."
                     },
                     {
                         id: "accidentTime",
                         label: "Time",
-                        type: "text",
+                        type: "time",
                         placeholder: "14:30",
                         extra_info: "Include exact or approximate time of the event."
                     },

--- a/src/constants/initial-reports.js
+++ b/src/constants/initial-reports.js
@@ -485,6 +485,12 @@ const PATIENT_INFO = [
                     },
                     { id: "packsPerDay", label: "Packs per day", type: "text", placeholder: "0" },
                     { id: "smokingYears", label: "Years smoking", type: "text", placeholder: "0" },
+                    {
+                        id: "drinkStatus",
+                        label: "Do you drink alcohol?",
+                        type: "radio",
+                        options: ["none", "yes", "no"],
+                    },
                     { id: "beerPerWeek", label: "Beer per week", type: "text", placeholder: "3" },
                     { id: "liquorPerWeek", label: "Liquor per week", type: "text", placeholder: "1" },
                     { id: "winePerWeek", label: "Wine per week", type: "text", placeholder: "0" },

--- a/src/features/auth/components/Login.jsx
+++ b/src/features/auth/components/Login.jsx
@@ -1,25 +1,27 @@
 import { useState, useEffect } from "react";
-import { useSelector, useDispatch} from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { useLoginMutation } from "../../../services/api";
 import { useNavigate } from "react-router-dom";
-import { renderGmailExprs, renderPassword} from "../../../utils/renderUtilsFunc";
+import { renderGmailExprs, renderPassword } from "../../../utils/renderUtilsFunc";
 import { setEmailError, clearEmailError, setPasswordError, clearPasswordError } from "../../../state/forms/loginFormSlice";
 
 export default function Login() {
     const navigate = useNavigate();
-    const { user, isAuthenticated } = useSelector((state) => state.data.auth);
+    const userID = useSelector(state => state.data.auth.userID);
+    const isAuthenticated = useSelector(state => state.data.auth.isAuthenticated);
+    const role = useSelector(state => state.data.auth.role);
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [loginMutation, { isLoading, error: loginError }] = useLoginMutation();
     const dispatch = useDispatch();
     const errorEmail = useSelector(state => state.forms.loginForm.errors.email)
-    const pwError = useSelector (state => state.forms.loginForm.errors.password )
+    const pwError = useSelector(state => state.forms.loginForm.errors.password)
 
     const handleEmailBlur = () => {
         try {
             const good = renderGmailExprs(email);
             dispatch(clearEmailError(good));
-        } catch(err){
+        } catch (err) {
             dispatch(setEmailError(err.message));
         }
     }
@@ -36,13 +38,13 @@ export default function Login() {
 
     useEffect(() => {
         if (isAuthenticated) {
-            if (user.role === "admin") {
-                navigate(`/admin/${user.id}`);
+            if (role === "admin") {
+                navigate(`/admin/${userID}`);
             } else {
-                navigate(`/dashboard/${user.id}`);
+                navigate(`/dashboard/${userID}`);
             }
         }
-    }, [isAuthenticated, navigate, user]);
+    }, [isAuthenticated, navigate, userID]);
 
     const handleLogin = async (e) => {
         e.preventDefault();
@@ -77,7 +79,7 @@ export default function Login() {
                             autoComplete="email"
                             value={email}
                             onChange={(e) => setEmail(e.target.value)}
-                            onBlur = {handleEmailBlur}
+                            onBlur={handleEmailBlur}
                             placeholder="you@example.com"
                             className="mt-2 block w-full rounded-md border px-3 py-1.5 text-base text-gray-900 placeholder:text-gray-400 focus:outline-indigo-600"
                         />
@@ -96,7 +98,7 @@ export default function Login() {
                             autoComplete="current-password"
                             value={password}
                             onChange={(e) => setPassword(e.target.value)}
-                            onBlur = {handlePwBlur}
+                            onBlur={handlePwBlur}
                             className="mt-2 block w-full rounded-md border px-3 py-1.5 text-base text-gray-900 placeholder:text-gray-400 focus:outline-indigo-600"
                         />
                         {pwError && <p className="text-red-500">{pwError}</p>}

--- a/src/features/report/components/user/HumanBody.jsx
+++ b/src/features/report/components/user/HumanBody.jsx
@@ -221,7 +221,7 @@ export default function PainChartSection({
                                                         </h3>
                                                         <div key={field.id} className="text-center mb-6">
                                                             <Label className="font-semibold text-sm">{field.label}</Label>
-                                                            <div className="relative w-32 mx-auto">
+                                                            <div className="w-32 mx-auto space-y-1 mt-2">
                                                                 <Slider
                                                                     min={0}
                                                                     max={10}
@@ -229,7 +229,7 @@ export default function PainChartSection({
                                                                     value={[painMap[field.id] || 0]}
                                                                     onValueChange={(val) => handleSliderChange(field.id, val)}
                                                                 />
-                                                                <div className="absolute inset-x-0 bottom-0 text-center text-xs">
+                                                                <div className="text-center text-xs">
                                                                     {painMap[field.id] || 0} / 10
                                                                 </div>
                                                             </div>

--- a/src/features/report/components/user/HumanBody.jsx
+++ b/src/features/report/components/user/HumanBody.jsx
@@ -174,29 +174,40 @@ export default function PainChartSection({
     };
 
     return (
-        <div className="relative flex justify-center items-start gap-4 w-full">
-            <div className="flex flex-col gap-6 mt-20">
+        <div className="w-full flex flex-col items-center">
+            <div className="scale-90">
+                <Suspense fallback={<div>Loading...</div>}>
+                    <BodyComponent
+                        bodyModel={model}
+                        onClick={handleBodyClick}
+                        partsInput={partsInput}
+                    />
+                </Suspense>
+                <div className="flex justify-center gap-2 mt-2 text-md font-semibold">
+                    <button onClick={() => setModel("male")}>Male</button>
+                    <button onClick={() => setModel("female")}>Female</button>
+                </div>
+            </div>
+            <div className="flex flex-wrap justify-center gap-4 mt-6">
                 {painFields.map((field) => (
                     <div key={field.id} className="text-center">
                         <Label className="font-semibold text-sm">{field.label}</Label>
-                        <Dialog open={openFieldId === field.id} onOpenChange={(isOpen) => {
-                            if (!isOpen) setopenFieldId(null);
-                        }} >
-                            <DialogTrigger asChild >
+                        <Dialog
+                            open={openFieldId === field.id}
+                            onOpenChange={(isOpen) => {
+                                if (!isOpen) setopenFieldId(null);
+                            }}
+                        >
+                            <DialogTrigger asChild>
                                 <Button
                                     id={field.id}
                                     size="sm"
                                     variant="outline"
                                     onClick={() => setopenFieldId(field.id)}
                                 >
-                                    {typeof painMap[field.id] === "number"
-                                        ? painMap[field.id]
-                                        : "0"}{" "}
-                                    / 10
-
+                                    {typeof painMap[field.id] === "number" ? painMap[field.id] : "0"} / 10
                                 </Button>
                             </DialogTrigger>
-
                             <DialogContent className="max-w-2xl w-full bg-white rounded-lg shadow-lg">
                                 <DialogHeader>
                                     <DialogTitle>Details your {field.label}</DialogTitle>
@@ -237,26 +248,10 @@ export default function PainChartSection({
                                         Close
                                     </Button>
                                 </div>
-
                             </DialogContent>
-
                         </Dialog>
                     </div>
                 ))}
-            </div>
-            {/* Body Model */}
-            <div className="scale-90">
-                <Suspense fallback={<div>Loading...</div>}>
-                    <BodyComponent
-                        bodyModel={model}
-                        onClick={handleBodyClick}
-                        partsInput={partsInput}
-                    />
-                </Suspense>
-                <div className="flex justify-center gap-2 mt-2 text-md font-semibold">
-                    <button onClick={() => setModel("male")}>Male</button>
-                    <button onClick={() => setModel("female")}>Female</button>
-                </div>
             </div>
         </div>
     );

--- a/src/features/report/components/user/HumanBody.jsx
+++ b/src/features/report/components/user/HumanBody.jsx
@@ -223,14 +223,18 @@ export default function PainChartSection({
                                                             <Label className="font-semibold text-sm">{field.label}</Label>
                                                             <div className="w-32 mx-auto space-y-1 mt-2">
                                                                 <Slider
-                                                                    min={0}
+                                                                    min={1}
                                                                     max={10}
                                                                     step={1}
-                                                                    value={[painMap[field.id] || 0]}
+                                                                    value={[painMap[field.id] || 1]}
                                                                     onValueChange={(val) => handleSliderChange(field.id, val)}
                                                                 />
+                                                                <div className="text-xs flex justify-between px-2">
+                                                                    <span>1 - least hurt</span>
+                                                                    <span>10 - most hurt</span>
+                                                                </div>
                                                                 <div className="text-center text-xs">
-                                                                    {painMap[field.id] || 0} / 10
+                                                                    {painMap[field.id] || 1} / 10
                                                                 </div>
                                                             </div>
                                                         </div>

--- a/src/features/report/components/user/HumanBody.jsx
+++ b/src/features/report/components/user/HumanBody.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useState, lazy, Suspense } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import {
     Dialog,
@@ -8,7 +8,7 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "@/components/ui/dialog";
-import { BodyComponent } from "reactjs-human-body";
+const BodyComponent = lazy(() => import("reactjs-human-body").then(m => ({ default: m.BodyComponent || m.default })))
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
 import { Button } from "@/components/ui/button";
@@ -186,17 +186,17 @@ export default function PainChartSection({ painMap, setPainMap }) {
                                                         </h3>
                                                         <div key={field.id} className="text-center mb-6">
                                                             <Label className="font-semibold text-sm">{field.label}</Label>
-                                                            <Slider
-                                                                min={0}
-                                                                max={10}
-                                                                step={1}
-                                                                value={[painMap[field.id] || 0]}
-                                                                onValueChange={(val) => handleSliderChange(field.id, val)}
-                                                                className="w-32 mx-auto"
-                                                            />
-                                                            <div className="text-xs flex justify-between px-2">
-                                                                <span>0</span>
-                                                                <span>10</span>
+                                                            <div className="relative w-32 mx-auto">
+                                                                <Slider
+                                                                    min={0}
+                                                                    max={10}
+                                                                    step={1}
+                                                                    value={[painMap[field.id] || 0]}
+                                                                    onValueChange={(val) => handleSliderChange(field.id, val)}
+                                                                />
+                                                                <div className="absolute inset-x-0 bottom-0 text-center text-xs">
+                                                                    {painMap[field.id] || 0} / 10
+                                                                </div>
                                                             </div>
                                                         </div>
                                                         <div className="flex flex-col gap-4">
@@ -222,7 +222,9 @@ export default function PainChartSection({ painMap, setPainMap }) {
             </div>
             {/* Body Model */}
             <div className="scale-90">
-                <BodyComponent bodyModel={model} />
+                <Suspense fallback={<div>Loading...</div>}>
+                    <BodyComponent bodyModel={model} />
+                </Suspense>
                 <div className="flex justify-center gap-2 mt-2 text-md font-semibold">
                     <button onClick={() => setModel("male")}>Male</button>
                     <button onClick={() => setModel("female")}>Female</button>
@@ -262,17 +264,17 @@ export default function PainChartSection({ painMap, setPainMap }) {
                                                         </h3>
                                                         <div key={field.id} className="text-center mb-6">
                                                             <Label className="font-semibold text-sm">{field.label}</Label>
-                                                            <Slider
-                                                                min={0}
-                                                                max={10}
-                                                                step={1}
-                                                                value={[painMap[field.id] || 0]}
-                                                                onValueChange={(val) => handleSliderChange(field.id, val)}
-                                                                className="w-32 mx-auto"
-                                                            />
-                                                            <div className="text-xs flex justify-between px-2">
-                                                                <span>0</span>
-                                                                <span>10</span>
+                                                            <div className="relative w-32 mx-auto">
+                                                                <Slider
+                                                                    min={0}
+                                                                    max={10}
+                                                                    step={1}
+                                                                    value={[painMap[field.id] || 0]}
+                                                                    onValueChange={(val) => handleSliderChange(field.id, val)}
+                                                                />
+                                                                <div className="absolute inset-x-0 bottom-0 text-center text-xs">
+                                                                    {painMap[field.id] || 0} / 10
+                                                                </div>
                                                             </div>
                                                         </div>
                                                         <div className="flex flex-col gap-4">

--- a/src/features/report/components/user/HumanBody.jsx
+++ b/src/features/report/components/user/HumanBody.jsx
@@ -221,17 +221,23 @@ export default function PainChartSection({
                                                         </h3>
                                                         <div key={field.id} className="text-center mb-6">
                                                             <Label className="font-semibold text-sm">{field.label}</Label>
-                                                            <div className="w-32 mx-auto space-y-1 mt-2">
-                                                                <Slider
-                                                                    min={1}
-                                                                    max={10}
-                                                                    step={1}
-                                                                    value={[painMap[field.id] || 1]}
-                                                                    onValueChange={(val) => handleSliderChange(field.id, val)}
-                                                                />
+                                                            <div className="w-40 mx-auto space-y-1 mt-2">
+                                                                <div className="flex items-center gap-2">
+                                                                    <span className="text-xs w-4 text-left">1</span>
+                                                                    <Slider
+                                                                        min={1}
+                                                                        max={10}
+                                                                        step={1}
+                                                                        value={[painMap[field.id] || 1]}
+                                                                        onValueChange={(val) => handleSliderChange(field.id, val)}
+                                                                        className="flex-1"
+                                                                    />
+                                                                    <span className="text-xs w-4 text-right">10</span>
+                                                                </div>
                                                                 <div className="text-xs flex justify-between px-2">
-                                                                    <span>1 - least hurt</span>
-                                                                    <span>10 - most hurt</span>
+                                                                    <span>Minimal pain</span>
+                                                                    <span>mid</span>
+                                                                    <span>Max pain</span>
                                                                 </div>
                                                                 <div className="text-center text-xs">
                                                                     {painMap[field.id] || 1} / 10

--- a/src/features/report/components/user/HumanBody.jsx
+++ b/src/features/report/components/user/HumanBody.jsx
@@ -53,6 +53,7 @@ import { RenderQuesFuncs,
   RenderOtherQues }from "../../../../utils/renderQuesFuncs.jsx";
 
 export default function PainChartSection({
+    gender,
     painMap,
     setPainMap,
     formData,
@@ -177,7 +178,7 @@ export default function PainChartSection({
             <div className="scale-90">
                 <Suspense fallback={<div>Loading...</div>}>
                     <BodyComponent
-                        bodyModel="male"
+                        bodyModel={gender && gender.toLowerCase().includes("female") ? "female" : "male"}
                         onClick={handleBodyClick}
                         partsInput={partsInput}
                     />

--- a/src/features/report/components/user/HumanBody.jsx
+++ b/src/features/report/components/user/HumanBody.jsx
@@ -121,7 +121,6 @@ export default function PainChartSection({
         ]
     };
 
-    const [model, setModel] = useState("male");
     const [openFieldId, setopenFieldId] = useState(null);
 
     const partMap = {
@@ -178,15 +177,11 @@ export default function PainChartSection({
             <div className="scale-90">
                 <Suspense fallback={<div>Loading...</div>}>
                     <BodyComponent
-                        bodyModel={model}
+                        bodyModel="male"
                         onClick={handleBodyClick}
                         partsInput={partsInput}
                     />
                 </Suspense>
-                <div className="flex justify-center gap-2 mt-2 text-md font-semibold">
-                    <button onClick={() => setModel("male")}>Male</button>
-                    <button onClick={() => setModel("female")}>Female</button>
-                </div>
             </div>
             <div className="flex flex-wrap justify-center gap-4 mt-6">
                 {painFields.map((field) => (
@@ -223,7 +218,7 @@ export default function PainChartSection({
                                                             <Label className="font-semibold text-sm">{field.label}</Label>
                                                             <div className="w-40 mx-auto space-y-1 mt-2">
                                                                 <div className="flex items-center gap-2">
-                                                                    <span className="text-xs w-4 text-left">1</span>
+                                                                    <span className="text-xs w-6 text-left">1</span>
                                                                     <Slider
                                                                         min={1}
                                                                         max={10}
@@ -232,12 +227,12 @@ export default function PainChartSection({
                                                                         onValueChange={(val) => handleSliderChange(field.id, val)}
                                                                         className="flex-1"
                                                                     />
-                                                                    <span className="text-xs w-4 text-right">10</span>
+                                                                    <span className="text-xs w-6 text-right">10</span>
                                                                 </div>
-                                                                <div className="text-xs flex justify-between px-2">
-                                                                    <span>Minimal pain</span>
-                                                                    <span>mid</span>
-                                                                    <span>Max pain</span>
+                                                                <div className="text-xs flex justify-between px-4">
+                                                                    <span>Minimal</span>
+                                                                    <span className="flex-1 text-center"> </span>
+                                                                    <span>Max</span>
                                                                 </div>
                                                                 <div className="text-center text-xs">
                                                                     {painMap[field.id] || 1} / 10

--- a/src/features/report/components/user/HumanBody.jsx
+++ b/src/features/report/components/user/HumanBody.jsx
@@ -56,7 +56,13 @@ import { RenderQuesFuncs,
   RenderCheckboxQues,
   RenderOtherQues }from "../../../../utils/renderQuesFuncs.jsx";
 
-export default function PainChartSection({ painMap, setPainMap }) {
+export default function PainChartSection({
+    painMap,
+    setPainMap,
+    formData,
+    setFormData,
+    onRemove,
+}) {
     const objectHuman = {
         id: "3",
         title: "Pain & Symptom Evaluation",
@@ -121,7 +127,6 @@ export default function PainChartSection({ painMap, setPainMap }) {
     };
 
     const [model, setModel] = useState("male");
-    const [formData, setFormData] = useState({});
     const [openFieldId, setopenFieldId] = useState(null);
 
     const handleSliderChange = (id, value) => {
@@ -149,7 +154,17 @@ export default function PainChartSection({ painMap, setPainMap }) {
     };
 
     return (
-        <div className="flex justify-center items-start gap-4 w-full">
+        <div className="relative flex justify-center items-start gap-4 w-full">
+            {onRemove && (
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={onRemove}
+                    className="absolute right-0 top-0 text-red-600"
+                >
+                    Remove
+                </Button>
+            )}
             {/* Left Panel */}
             <div className="flex flex-col gap-6 mt-20">
                 {painFields.left.map((field) => (

--- a/src/features/report/components/user/HumanBody.jsx
+++ b/src/features/report/components/user/HumanBody.jsx
@@ -28,28 +28,24 @@ import {
     HoverCardContent,
 } from "@/components/ui/hover-card";
 
-const painFields = {
-    left: [
-        { id: "headache", label: "Headaches" },
-        { id: "upperBack", label: "Upper Back" },
-        { id: "arms", label: "Arms" },
-        { id: "lowerBack", label: "Lower Back" },
-        { id: "feet", label: "Feet" },
-        { id: "hips", label: "Hips" },
-        { id: "knees", label: "Knees" },
-        { id: "ankles", label: "Ankles" },
-    ],
-    right: [
-        { id: "neck", label: "Neck" },
-        { id: "shoulders", label: "Shoulders" },
-        { id: "midBack", label: "Mid Back" },
-        { id: "legs", label: "Legs" },
-        { id: "toes", label: "Toes" },
-        { id: "wrists", label: "Wrists" },
-        { id: "elbows", label: "Elbows" },
-        { id: "shoulderBlades", label: "Shoulder Blades" },
-    ],
-};
+const painFields = [
+    { id: "headache", label: "Headaches" },
+    { id: "neck", label: "Neck" },
+    { id: "shoulders", label: "Shoulders" },
+    { id: "upperBack", label: "Upper Back" },
+    { id: "midBack", label: "Mid Back" },
+    { id: "lowerBack", label: "Lower Back" },
+    { id: "shoulderBlades", label: "Shoulder Blades" },
+    { id: "arms", label: "Arms" },
+    { id: "wrists", label: "Wrists" },
+    { id: "elbows", label: "Elbows" },
+    { id: "hips", label: "Hips" },
+    { id: "legs", label: "Legs" },
+    { id: "knees", label: "Knees" },
+    { id: "ankles", label: "Ankles" },
+    { id: "feet", label: "Feet" },
+    { id: "toes", label: "Toes" },
+];
 import { RenderQuesFuncs,
   RenderTextAreaQues,
   RenderRadioQues,
@@ -61,7 +57,6 @@ export default function PainChartSection({
     setPainMap,
     formData,
     setFormData,
-    onRemove,
 }) {
     const objectHuman = {
         id: "3",
@@ -129,6 +124,31 @@ export default function PainChartSection({
     const [model, setModel] = useState("male");
     const [openFieldId, setopenFieldId] = useState(null);
 
+    const partMap = {
+        head: "headache",
+        leftShoulder: "shoulders",
+        rightShoulder: "shoulders",
+        chest: "upperBack",
+        stomach: "lowerBack",
+        leftArm: "arms",
+        rightArm: "arms",
+        leftHand: "wrists",
+        rightHand: "wrists",
+        leftLeg: "legs",
+        rightLeg: "legs",
+        leftFoot: "feet",
+        rightFoot: "feet",
+    };
+
+    const handleBodyClick = (part) => {
+        const field = partMap[part];
+        if (field) setopenFieldId(field);
+    };
+
+    const partsInput = Object.fromEntries(
+        Object.entries(partMap).map(([part, field]) => [part, { selected: !!painMap[field] }])
+    );
+
     const handleSliderChange = (id, value) => {
         setPainMap((prev) => ({
             ...prev,
@@ -155,19 +175,8 @@ export default function PainChartSection({
 
     return (
         <div className="relative flex justify-center items-start gap-4 w-full">
-            {onRemove && (
-                <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={onRemove}
-                    className="absolute right-0 top-0 text-red-600"
-                >
-                    Remove
-                </Button>
-            )}
-            {/* Left Panel */}
             <div className="flex flex-col gap-6 mt-20">
-                {painFields.left.map((field) => (
+                {painFields.map((field) => (
                     <div key={field.id} className="text-center">
                         <Label className="font-semibold text-sm">{field.label}</Label>
                         <Dialog open={openFieldId === field.id} onOpenChange={(isOpen) => {
@@ -238,78 +247,16 @@ export default function PainChartSection({
             {/* Body Model */}
             <div className="scale-90">
                 <Suspense fallback={<div>Loading...</div>}>
-                    <BodyComponent bodyModel={model} />
+                    <BodyComponent
+                        bodyModel={model}
+                        onClick={handleBodyClick}
+                        partsInput={partsInput}
+                    />
                 </Suspense>
                 <div className="flex justify-center gap-2 mt-2 text-md font-semibold">
                     <button onClick={() => setModel("male")}>Male</button>
                     <button onClick={() => setModel("female")}>Female</button>
                 </div>
-            </div>
-            {/* Right Panel */}
-            <div className="flex flex-col gap-6 mt-20">
-                {painFields.right.map((field) => (
-                    <div key={field.id} className="text-center">
-                        <Label className="font-semibold text-sm">{field.label}</Label>
-                        <Dialog open={openFieldId === field.id} onOpenChange={(isOpen) => {
-                            if (!isOpen) setopenFieldId(null);
-                        }}>
-                            <DialogTrigger asChild>
-                                <Button
-                                    id={field.id}
-                                    size="sm"
-                                    variant="outline"
-                                    onClick={() => setopenFieldId(field.id)}
-                                >
-                                    {typeof painMap[field.id] === "number"
-                                        ? painMap[field.id]
-                                        : "0"}{" "}
-                                    / 10
-                                </Button>
-                            </DialogTrigger>
-                            <DialogContent className="sm:max-w-2xl">
-                                <DialogHeader>
-                                    <DialogTitle>Details your {field.label}</DialogTitle>
-                                    <DialogDescription asChild>
-                                        <div className="flex-1 p-6 overflow-y-auto">
-                                            <Card>
-                                                <CardContent className="space-y-8">
-                                                    <section key={objectHuman.id}>
-                                                        <h3 className="text-xl font-semibold mb-4">
-                                                            Describe details of your {field.label}
-                                                        </h3>
-                                                        <div key={field.id} className="text-center mb-6">
-                                                            <Label className="font-semibold text-sm">{field.label}</Label>
-                                                            <div className="relative w-32 mx-auto">
-                                                                <Slider
-                                                                    min={0}
-                                                                    max={10}
-                                                                    step={1}
-                                                                    value={[painMap[field.id] || 0]}
-                                                                    onValueChange={(val) => handleSliderChange(field.id, val)}
-                                                                />
-                                                                <div className="absolute inset-x-0 bottom-0 text-center text-xs">
-                                                                    {painMap[field.id] || 0} / 10
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                        <div className="flex flex-col gap-4">
-                                                            {objectHuman.questions.map((question) => newrenderQuestion(question))}
-                                                        </div>
-                                                    </section>
-                                                </CardContent>
-                                            </Card>
-                                        </div>
-                                    </DialogDescription>
-                                </DialogHeader>
-                                <div className="flex justify-end mt-4">
-                                    <Button variant="outline" onClick={closeDialog}>
-                                        Close
-                                    </Button>
-                                </div>
-                            </DialogContent>
-                        </Dialog>
-                    </div>
-                ))}
             </div>
         </div>
     );

--- a/src/features/report/components/user/InitialReportForm.jsx
+++ b/src/features/report/components/user/InitialReportForm.jsx
@@ -72,7 +72,7 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
         q.fields.forEach((f) => {
           if (formData[f.id] !== undefined) data[f.id] = formData[f.id];
         });
-      } else if (q.type === "painChart") {
+      } else if (q.type === "image-map") {
         data.painEvaluations = painEvaluations;
       } else if (formData[q.id] !== undefined) {
         data[q.id] = formData[q.id];
@@ -159,7 +159,7 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
             commonFieldsetClasses={baseClasses}
           />
         );
-      case "painChart":
+      case "image-map":
         return (
           <fieldset key={question.id} className={baseClasses}>
             <legend className="text-sm font-medium text-muted-foreground px-2">{question.label}</legend>
@@ -192,29 +192,9 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
                       return list;
                     })
                   }
-                  onRemove={
-                    painEvaluations.length > 1
-                      ? () =>
-                          setPainEvaluations((prev) =>
-                            prev.filter((_, i) => i !== idx)
-                          )
-                      : null
-                  }
                 />
               </div>
             ))}
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() =>
-                setPainEvaluations((prev) => [
-                  ...prev,
-                  { painMap: {}, formData: {} },
-                ])
-              }
-            >
-              Add Evaluation
-            </Button>
           </fieldset>
         );
       default:

--- a/src/features/report/components/user/InitialReportForm.jsx
+++ b/src/features/report/components/user/InitialReportForm.jsx
@@ -26,6 +26,7 @@ import {
 export default function InitialReportForm({ onSubmit, initialData = {}, onBack }) {
   const [formData, setFormData] = useState({
     currentlyWorking: "none",
+    drinkStatus: "none",
     ...(initialData.formData || {}),
   });
   const [currentSectionIndex, setCurrentSectionIndex] = useState(0);
@@ -111,6 +112,14 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
   };
 
   const renderQuestion = (question) => {
+    if (
+      question.id === "femaleOnly" ||
+      question.id === "femaleOnlyDetails"
+    ) {
+      if (!formData.gender || formData.gender.toLowerCase() !== "female") {
+        return null;
+      }
+    }
     switch (question.type) {
       case "group":
         return (

--- a/src/features/report/components/user/InitialReportForm.jsx
+++ b/src/features/report/components/user/InitialReportForm.jsx
@@ -13,10 +13,10 @@ import {
 import PATIENT_INFO from "../../../../constants/initial-reports";
 import PainChartSection from "./HumanBody";
 
-export default function InitialReportForm({onSubmit}) {
-  const [formData, setFormData] = useState({});
+export default function InitialReportForm({ onSubmit, initialData = {}, onBack }) {
+  const [formData, setFormData] = useState(initialData.formData || {});
   const [currentSectionIndex, setCurrentSectionIndex] = useState(0);
-  const [painMap, setPainMap] = useState({});
+  const [painMap, setPainMap] = useState(initialData.painMap || {});
   const [formErrors, setFormErrors] = useState({});
 
   const currentSection = PATIENT_INFO[currentSectionIndex];
@@ -118,6 +118,13 @@ export default function InitialReportForm({onSubmit}) {
       }}
       className="flex flex-col md:flex-row flex-1 h-full overflow-hidden mb-8"
     >
+      {onBack && (
+        <div className="mb-4 md:hidden">
+          <Button variant="outline" size="sm" onClick={onBack}>
+            Back to reports
+          </Button>
+        </div>
+      )}
       <div className="hidden md:block md:w-80 border-r p-4 overflow-y-auto max-h-full">
         <h2 className="text-lg font-semibold mb-4">Initial Reports</h2>
         <Accordion type="single" collapsible className="space-y-2" value={currentSection.title}>
@@ -130,8 +137,13 @@ export default function InitialReportForm({onSubmit}) {
       </div>
       <div className="flex-1 p-4 md:p-6 overflow-y-auto h-full">
         <Card>
-          <CardHeader>
+          <CardHeader className="flex justify-between items-center">
             <CardTitle>{currentSection.title}</CardTitle>
+            {onBack && (
+              <Button variant="outline" size="sm" onClick={onBack}>
+                Back
+              </Button>
+            )}
           </CardHeader>
           <CardContent className="space-y-6">
             {Object.values(formErrors).length > 0 && (
@@ -155,3 +167,4 @@ export default function InitialReportForm({onSubmit}) {
     </form>
   );
 }
+

--- a/src/features/report/components/user/InitialReportForm.jsx
+++ b/src/features/report/components/user/InitialReportForm.jsx
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 import { Accordion, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ArrowLeft } from "lucide-react";
 
 import {
     RenderQuesFuncs,
@@ -17,6 +19,7 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
   const [formData, setFormData] = useState(initialData.formData || {});
   const [currentSectionIndex, setCurrentSectionIndex] = useState(0);
   const [painMap, setPainMap] = useState(initialData.painMap || {});
+  const [reportName, setReportName] = useState(initialData.name || "");
   const [formErrors, setFormErrors] = useState({});
 
   const currentSection = PATIENT_INFO[currentSectionIndex];
@@ -113,18 +116,24 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
       onSubmit={(e) => {
         e.preventDefault();
         if (validate()) {
-          onSubmit({formData, painMap});
+          onSubmit({ formData, painMap, name: reportName });
         }
       }}
       className="flex flex-col md:flex-row flex-1 h-full overflow-hidden mb-8"
     >
-      {onBack && (
-        <div className="mb-4 md:hidden">
-          <Button variant="outline" size="sm" onClick={onBack}>
-            Back to reports
+      <div className="flex items-center gap-2 mb-4 md:hidden">
+        {onBack && (
+          <Button variant="ghost" size="icon" onClick={onBack}>
+            <ArrowLeft className="h-5 w-5" />
           </Button>
-        </div>
-      )}
+        )}
+        <Input
+          placeholder="Report name"
+          value={reportName}
+          onChange={(e) => setReportName(e.target.value)}
+          className="h-8"
+        />
+      </div>
       <div className="hidden md:block md:w-80 border-r p-4 overflow-y-auto max-h-full">
         <h2 className="text-lg font-semibold mb-4">Initial Reports</h2>
         <Accordion type="single" collapsible className="space-y-2" value={currentSection.title}>
@@ -138,12 +147,22 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
       <div className="flex-1 p-4 md:p-6 overflow-y-auto h-full">
         <Card>
           <CardHeader className="flex justify-between items-center">
-            <CardTitle>{currentSection.title}</CardTitle>
-            {onBack && (
-              <Button variant="outline" size="sm" onClick={onBack}>
-                Back
-              </Button>
-            )}
+            <div className="flex items-center gap-2">
+              {onBack && (
+                <Button variant="ghost" size="icon" onClick={onBack} className="hidden md:inline-flex">
+                  <ArrowLeft className="h-5 w-5" />
+                </Button>
+              )}
+              <CardTitle>{currentSection.title}</CardTitle>
+            </div>
+            <div className="w-48">
+              <Input
+                placeholder="Report name"
+                value={reportName}
+                onChange={(e) => setReportName(e.target.value)}
+                className="h-8"
+              />
+            </div>
           </CardHeader>
           <CardContent className="space-y-6">
             {Object.values(formErrors).length > 0 && (

--- a/src/features/report/components/user/InitialReportForm.jsx
+++ b/src/features/report/components/user/InitialReportForm.jsx
@@ -119,21 +119,18 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
           onSubmit({ formData, painMap, name: reportName });
         }
       }}
-      className="flex flex-col md:flex-row flex-1 h-full overflow-hidden mb-8"
+      className="relative flex flex-col md:flex-row flex-1 h-full overflow-hidden mb-8"
     >
-      <div className="flex items-center gap-2 mb-4 md:hidden">
-        {onBack && (
-          <Button variant="ghost" size="icon" onClick={onBack}>
-            <ArrowLeft className="h-5 w-5" />
-          </Button>
-        )}
-        <Input
-          placeholder="Report name"
-          value={reportName}
-          onChange={(e) => setReportName(e.target.value)}
-          className="h-8"
-        />
-      </div>
+      {onBack && (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onBack}
+          className="absolute left-2 top-2 md:left-4 md:top-4 z-10"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+      )}
       <div className="hidden md:block md:w-80 border-r p-4 overflow-y-auto max-h-full">
         <h2 className="text-lg font-semibold mb-4">Initial Reports</h2>
         <Accordion type="single" collapsible className="space-y-2" value={currentSection.title}>
@@ -148,11 +145,6 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
         <Card>
           <CardHeader className="flex justify-between items-center">
             <div className="flex items-center gap-2">
-              {onBack && (
-                <Button variant="ghost" size="icon" onClick={onBack} className="hidden md:inline-flex">
-                  <ArrowLeft className="h-5 w-5" />
-                </Button>
-              )}
               <CardTitle>{currentSection.title}</CardTitle>
             </div>
             <div className="w-48">

--- a/src/features/report/components/user/InitialReportForm.jsx
+++ b/src/features/report/components/user/InitialReportForm.jsx
@@ -6,11 +6,11 @@ import { Input } from "@/components/ui/input";
 import { ArrowLeft } from "lucide-react";
 
 import {
-    RenderQuesFuncs,
-    RenderTextAreaQues,
-    RenderRadioQues,
-    RenderCheckboxQues,
-    RenderOtherQues,
+  RenderQuesFuncs,
+  RenderTextAreaQues,
+  RenderRadioQues,
+  RenderCheckboxQues,
+  RenderOtherQues,
 } from "@/utils/renderQuesFuncs";
 import PATIENT_INFO from "../../../../constants/initial-reports";
 import PainChartSection from "./HumanBody";
@@ -267,26 +267,26 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
         >
           <Card>
             <CardHeader>
-            {editingName ? (
-              <Input
-                autoFocus
-                value={reportName}
-                onChange={(e) => setReportName(e.target.value)}
-                onBlur={() => setEditingName(false)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    setEditingName(false);
-                  }
-                }}
-                className="mt-1"
-              />
-            ) : (
-              <CardTitle onClick={() => setEditingName(true)} className="cursor-pointer">
-                {reportName || "Untitled Report"}
-              </CardTitle>
-            )}
-            <p className="text-sm text-muted-foreground mt-1">{currentSection.title}</p>
+              {editingName ? (
+                <Input
+                  autoFocus
+                  value={reportName}
+                  onChange={(e) => setReportName(e.target.value)}
+                  onBlur={() => setEditingName(false)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      setEditingName(false);
+                    }
+                  }}
+                  className="mt-1"
+                />
+              ) : (
+                <CardTitle onClick={() => setEditingName(true)} className="cursor-pointer">
+                  {reportName || "Untitled Report"}
+                </CardTitle>
+              )}
+              <p className="text-sm text-muted-foreground mt-1">{currentSection.title}</p>
             </CardHeader>
             <CardContent className="space-y-6">
               {Object.values(formErrors).length > 0 && (
@@ -308,16 +308,21 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
                   </Button>
                 )}
                 <div className="space-x-2">
+                  {/* show Next if not at last */}
                   {currentSectionIndex < PATIENT_INFO.length - 1 && (
                     <Button
                       type="button"
                       variant="secondary"
-                      onClick={() => setCurrentSectionIndex((i) => i + 1)}
+                      onClick={() => setCurrentSectionIndex(i => i + 1)}
                     >
                       Next
                     </Button>
                   )}
-                  <Button type="submit">Save Section</Button>
+
+                  {/* show Save on the last section */}
+                  {currentSectionIndex === PATIENT_INFO.length - 1 && (
+                    <Button type="submit">Save Section</Button>
+                  )}
                 </div>
               </div>
             </CardContent>

--- a/src/features/report/components/user/InitialReportForm.jsx
+++ b/src/features/report/components/user/InitialReportForm.jsx
@@ -3,6 +3,7 @@ import { Accordion, AccordionItem, AccordionTrigger } from "@/components/ui/acco
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { ArrowLeft } from "lucide-react";
 
 import {
@@ -143,20 +144,20 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
       </div>
       <div className="flex-1 p-4 md:p-6 overflow-y-auto h-full">
         <Card>
-          <CardHeader className="flex justify-between items-center">
-            <div className="flex items-center gap-2">
-              <CardTitle>{currentSection.title}</CardTitle>
-            </div>
-            <div className="w-48">
+          <CardHeader>
+            <CardTitle>{currentSection.title}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div>
+              <Label htmlFor="report-name">Report name</Label>
               <Input
+                id="report-name"
                 placeholder="Report name"
                 value={reportName}
                 onChange={(e) => setReportName(e.target.value)}
-                className="h-8"
+                className="mt-1"
               />
             </div>
-          </CardHeader>
-          <CardContent className="space-y-6">
             {Object.values(formErrors).length > 0 && (
               <div className="text-red-500 text-sm space-y-1">
                 {Object.entries(formErrors).map(([k,v]) => (

--- a/src/features/report/components/user/InitialReportForm.jsx
+++ b/src/features/report/components/user/InitialReportForm.jsx
@@ -1,0 +1,157 @@
+import React, { useState } from "react";
+import { Accordion, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+import {
+    RenderQuesFuncs,
+    RenderTextAreaQues,
+    RenderRadioQues,
+    RenderCheckboxQues,
+    RenderOtherQues,
+} from "@/utils/renderQuesFuncs";
+import PATIENT_INFO from "../../../../constants/initial-reports";
+import PainChartSection from "./HumanBody";
+
+export default function InitialReportForm({onSubmit}) {
+  const [formData, setFormData] = useState({});
+  const [currentSectionIndex, setCurrentSectionIndex] = useState(0);
+  const [painMap, setPainMap] = useState({});
+  const [formErrors, setFormErrors] = useState({});
+
+  const currentSection = PATIENT_INFO[currentSectionIndex];
+  const baseClasses = "border rounded-md p-4 space-y-4 mb-4 bg-white shadow-sm";
+
+  const validate = () => {
+    const errs = {};
+    if (formData.ssn && !/^\d{3}-\d{2}-\d{4}$/.test(formData.ssn)) {
+      errs.ssn = "Invalid SSN format";
+    }
+    const phoneFields = Object.keys(formData).filter((k) => k.toLowerCase().includes("phone"));
+    phoneFields.forEach((field) => {
+      if (formData[field] && !/^(?:\(\d{3}\)|\d{3})[-.\s]?\d{3}[-.\s]?\d{4}$/.test(formData[field])) {
+        errs[field] = "Invalid phone number";
+      }
+    });
+    const dateFields = ["dob", "accidentDate"];
+    dateFields.forEach((field) => {
+      if (formData[field]) {
+        const d = new Date(formData[field]);
+        if (isNaN(d)) errs[field] = "Invalid date";
+      }
+    });
+    setFormErrors(errs);
+    return Object.keys(errs).length === 0;
+  };
+
+  const renderQuestion = (question) => {
+    switch (question.type) {
+      case "group":
+        return (
+          <RenderQuesFuncs
+            key={question.id}
+            question={question}
+            formData={formData}
+            setFormData={setFormData}
+            commonFieldsetClasses={baseClasses}
+          />
+        );
+      case "textarea":
+        return (
+          <RenderTextAreaQues
+            key={question.id}
+            question={question}
+            formData={formData}
+            setFormData={setFormData}
+            commonFieldsetClasses={baseClasses}
+          />
+        );
+      case "radio":
+        return (
+          <RenderRadioQues
+            key={question.id}
+            question={question}
+            formData={formData}
+            setFormData={setFormData}
+            commonFieldsetClasses={baseClasses}
+          />
+        );
+      case "checkbox":
+        return (
+          <RenderCheckboxQues
+            key={question.id}
+            question={question}
+            formData={formData}
+            setFormData={setFormData}
+            commonFieldsetClasses={baseClasses}
+          />
+        );
+      case "other":
+        return (
+          <RenderOtherQues
+            key={question.id}
+            question={question}
+            formData={formData}
+            setFormData={setFormData}
+            commonFieldsetClasses={baseClasses}
+          />
+        );
+      case "painChart":
+        return (
+          <fieldset key={question.id} className={baseClasses}>
+            <legend className="text-sm font-medium text-muted-foreground px-2">{question.label}</legend>
+            <PainChartSection painMap={painMap} setPainMap={setPainMap} />
+          </fieldset>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (validate()) {
+          onSubmit({formData, painMap});
+        }
+      }}
+      className="flex flex-col md:flex-row flex-1 h-full overflow-hidden mb-8"
+    >
+      <div className="hidden md:block md:w-80 border-r p-4 overflow-y-auto max-h-full">
+        <h2 className="text-lg font-semibold mb-4">Initial Reports</h2>
+        <Accordion type="single" collapsible className="space-y-2" value={currentSection.title}>
+          {PATIENT_INFO.map((section, idx) => (
+            <AccordionItem key={section.id} value={section.title} onClick={() => setCurrentSectionIndex(idx)}>
+              <AccordionTrigger>{section.title}</AccordionTrigger>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </div>
+      <div className="flex-1 p-4 md:p-6 overflow-y-auto h-full">
+        <Card>
+          <CardHeader>
+            <CardTitle>{currentSection.title}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {Object.values(formErrors).length > 0 && (
+              <div className="text-red-500 text-sm space-y-1">
+                {Object.entries(formErrors).map(([k,v]) => (
+                  <div key={k}>{v}</div>
+                ))}
+              </div>
+            )}
+            {currentSection.questions.map((q) => renderQuestion(q))}
+            <div className="flex justify-end pt-4">
+              {currentSectionIndex < PATIENT_INFO.length - 1 ? (
+                <Button onClick={() => setCurrentSectionIndex((i) => i + 1)}>Next</Button>
+              ) : (
+                <Button type="submit">Submit</Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </form>
+  );
+}

--- a/src/features/report/components/user/InitialReportForm.jsx
+++ b/src/features/report/components/user/InitialReportForm.jsx
@@ -14,14 +14,6 @@ import {
 } from "@/utils/renderQuesFuncs";
 import PATIENT_INFO from "../../../../constants/initial-reports";
 import PainChartSection from "./HumanBody";
-import {
-  useSubmitPatientIntakeMutation,
-  useSubmitAccidentDetailsMutation,
-  useSubmitPainEvaluationMutation,
-  useSubmitSymptomDescriptionMutation,
-  useSubmitRecoveryImpactMutation,
-  useSubmitHealthHistoryMutation,
-} from "@/services/api";
 
 export default function InitialReportForm({ onSubmit, initialData = {}, onBack }) {
   const [formData, setFormData] = useState({
@@ -37,12 +29,6 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
   const [editingName, setEditingName] = useState(false);
   const [formErrors, setFormErrors] = useState({});
 
-  const [submitSection1] = useSubmitPatientIntakeMutation();
-  const [submitSection2] = useSubmitAccidentDetailsMutation();
-  const [submitSection3] = useSubmitPainEvaluationMutation();
-  const [submitSection4] = useSubmitSymptomDescriptionMutation();
-  const [submitSection5] = useSubmitRecoveryImpactMutation();
-  const [submitSection6] = useSubmitHealthHistoryMutation();
 
   const currentSection = PATIENT_INFO[currentSectionIndex];
   const baseClasses = "border rounded-md p-4 space-y-4 mb-4 bg-white shadow-sm";
@@ -69,45 +55,13 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
     return Object.keys(errs).length === 0;
   };
 
-  const collectSectionData = () => {
-    const data = {};
-    currentSection.questions.forEach((q) => {
-      if (q.type === "group") {
-        q.fields.forEach((f) => {
-          if (formData[f.id] !== undefined) data[f.id] = formData[f.id];
-        });
-      } else if (q.type === "image-map") {
-        data.painEvaluations = painEvaluations;
-      } else if (formData[q.id] !== undefined) {
-        data[q.id] = formData[q.id];
-      }
-    });
-    data.name = reportName;
-    return data;
-  };
 
-  const submitters = [
-    submitSection1,
-    submitSection2,
-    submitSection3,
-    submitSection4,
-    submitSection5,
-    submitSection6,
-  ];
-
-  const handleSectionSubmit = async () => {
+  const handleSectionSubmit = () => {
     if (!validate()) return;
-    const data = collectSectionData();
-    const submit = submitters[currentSectionIndex];
-    try {
-      await submit(data).unwrap();
-      if (currentSectionIndex < PATIENT_INFO.length - 1) {
-        setCurrentSectionIndex((i) => i + 1);
-      } else {
-        onSubmit({ formData, painEvaluations, name: reportName });
-      }
-    } catch (err) {
-      console.error(err);
+    if (currentSectionIndex < PATIENT_INFO.length - 1) {
+      setCurrentSectionIndex((i) => i + 1);
+    } else {
+      onSubmit({ formData, painEvaluations, name: reportName });
     }
   };
 
@@ -276,7 +230,16 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
               </div>
             )}
             {currentSection.questions.map((q) => renderQuestion(q))}
-            <div className="flex justify-end pt-4">
+            <div className="flex justify-between pt-4">
+              {currentSectionIndex > 0 && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setCurrentSectionIndex((i) => i - 1)}
+                >
+                  Previous
+                </Button>
+              )}
               <Button type="submit">
                 {currentSectionIndex < PATIENT_INFO.length - 1 ? "Next" : "Submit"}
               </Button>

--- a/src/features/report/components/user/InitialReportForm.jsx
+++ b/src/features/report/components/user/InitialReportForm.jsx
@@ -3,7 +3,6 @@ import { Accordion, AccordionItem, AccordionTrigger } from "@/components/ui/acco
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { ArrowLeft } from "lucide-react";
 
 import {
@@ -31,6 +30,7 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
     initialData.painEvaluations || [{ painMap: {}, formData: {} }]
   );
   const [reportName, setReportName] = useState(initialData.name || "");
+  const [editingName, setEditingName] = useState(false);
   const [formErrors, setFormErrors] = useState({});
 
   const [submitSection1] = useSubmitPatientIntakeMutation();
@@ -253,19 +253,28 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
       <div className="flex-1 p-4 md:p-6 overflow-y-auto h-full">
         <Card>
           <CardHeader>
-            <CardTitle>{currentSection.title}</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <div>
-              <Label htmlFor="report-name">Report name</Label>
+            {editingName ? (
               <Input
-                id="report-name"
-                placeholder="Report name"
+                autoFocus
                 value={reportName}
                 onChange={(e) => setReportName(e.target.value)}
+                onBlur={() => setEditingName(false)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    setEditingName(false);
+                  }
+                }}
                 className="mt-1"
               />
-            </div>
+            ) : (
+              <CardTitle onClick={() => setEditingName(true)} className="cursor-pointer">
+                {reportName || "Untitled Report"}
+              </CardTitle>
+            )}
+            <p className="text-sm text-muted-foreground mt-1">{currentSection.title}</p>
+          </CardHeader>
+          <CardContent className="space-y-6">
             {Object.values(formErrors).length > 0 && (
               <div className="text-red-500 text-sm space-y-1">
                 {Object.entries(formErrors).map(([k,v]) => (

--- a/src/features/report/components/user/InitialReportForm.jsx
+++ b/src/features/report/components/user/InitialReportForm.jsx
@@ -24,7 +24,10 @@ import {
 } from "@/services/api";
 
 export default function InitialReportForm({ onSubmit, initialData = {}, onBack }) {
-  const [formData, setFormData] = useState(initialData.formData || {});
+  const [formData, setFormData] = useState({
+    currentlyWorking: "none",
+    ...(initialData.formData || {}),
+  });
   const [currentSectionIndex, setCurrentSectionIndex] = useState(0);
   const [painEvaluations, setPainEvaluations] = useState(
     initialData.painEvaluations || [{ painMap: {}, formData: {} }]
@@ -166,6 +169,7 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
             {painEvaluations.map((ev, idx) => (
               <div key={idx} className="mb-8">
                 <PainChartSection
+                  gender={formData.gender}
                   painMap={ev.painMap}
                   setPainMap={(updater) =>
                     setPainEvaluations((prev) => {

--- a/src/features/report/components/user/InitialReportForm.jsx
+++ b/src/features/report/components/user/InitialReportForm.jsx
@@ -109,7 +109,23 @@ export default function InitialReportForm({ onSubmit, initialData = {}, onBack }
         await submitters[currentSectionIndex]({ formData: subset, name: reportName });
       }
       if (currentSectionIndex === PATIENT_INFO.length - 1) {
-        onSubmit({ formData, painEvaluations, name: reportName });
+        const sectionData = PATIENT_INFO.map((_, idx) => {
+          const ids = sectionFieldIds[idx]
+          const obj = {}
+          ids.forEach((id) => {
+            if (formData[id] !== undefined) obj[id] = formData[id]
+          })
+          return obj
+        })
+        onSubmit({
+          patientIntake: sectionData[0],
+          accidentDetails: sectionData[1],
+          painEvaluations,
+          symptomDescription: sectionData[3],
+          recoveryImpact: sectionData[4],
+          healthHistory: sectionData[5],
+          name: reportName,
+        })
       }
     } catch (err) {
       console.error(err);

--- a/src/features/report/components/user/Report.jsx
+++ b/src/features/report/components/user/Report.jsx
@@ -7,7 +7,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { FolderIcon, PlusIcon, X } from "lucide-react"
+import {
+  FolderIcon,
+  HomeIcon,
+  FilesIcon,
+  ImagesIcon,
+  MusicIcon,
+  VideoIcon,
+  DownloadIcon,
+  PlusIcon,
+  X,
+} from "lucide-react"
 import InitialReportForm from "./InitialReportForm"
 import { useDeleteReportMutation } from "@/services/api"
 
@@ -77,46 +87,92 @@ export default function Report() {
     }
 
     return (
-        <div className="p-4 md:p-6">
-            <div className="mb-4 flex justify-end">
-                <Select value={sortOption} onValueChange={setSortOption}>
-                    <SelectTrigger className="w-40">
-                        <SelectValue placeholder="Sort" />
-                    </SelectTrigger>
-                    <SelectContent>
-                        <SelectItem value="date">Newest</SelectItem>
-                        <SelectItem value="name">Alphabetical</SelectItem>
-                    </SelectContent>
-                </Select>
-            </div>
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-                {sortedReports.map((rep, idx) => (
-                    <div
-                        key={rep.id}
-                        className="group relative rounded-md border border-gray-200 bg-white p-4 shadow-sm transition-all hover:border-gray-300 cursor-pointer"
-                        onClick={() => setSelectedId(rep.id)}
-                    >
-                        <button
-                            onClick={(e) => handleDelete(rep.id, e)}
-                            className="absolute left-2 top-2 text-gray-400 hover:text-red-600 opacity-0 group-hover:opacity-100"
-                        >
-                            <X className="h-4 w-4" />
-                        </button>
-                        <div className="flex h-20 items-center justify-center">
-                            <FolderIcon className="h-12 w-12 text-gray-500 group-hover:text-gray-700" />
-                        </div>
-                        <div className="mt-2 text-center">
-                            <span className="text-sm font-medium text-gray-900">{rep.name || `Report ${idx + 1}`}</span>
-                        </div>
+        <div className="flex h-screen w-full">
+            <div className="hidden h-full w-64 shrink-0 border-r bg-gray-100 dark:border-gray-800 dark:bg-gray-900 lg:block">
+                <div className="flex h-full flex-col gap-4 p-4">
+                    <div className="flex items-center gap-2 font-semibold">
+                        <FolderIcon className="h-6 w-6" />
+                        <span>File Explorer</span>
                     </div>
-                ))}
-                <button
-                    onClick={addReport}
-                    className="flex flex-col items-center justify-center rounded-md border border-dashed border-gray-300 p-4 hover:border-gray-400"
-                >
-                    <PlusIcon className="h-8 w-8 text-gray-500" />
-                    <span className="mt-2 text-sm">Add Report</span>
-                </button>
+                    <nav className="flex-1 space-y-2 overflow-auto">
+                        <div className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-800">
+                            <HomeIcon className="h-4 w-4" />
+                            Home
+                        </div>
+                        <div className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-800">
+                            <FilesIcon className="h-4 w-4" />
+                            Documents
+                        </div>
+                        <div className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-800">
+                            <ImagesIcon className="h-4 w-4" />
+                            Images
+                        </div>
+                        <div className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-800">
+                            <MusicIcon className="h-4 w-4" />
+                            Music
+                        </div>
+                        <div className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-800">
+                            <VideoIcon className="h-4 w-4" />
+                            Videos
+                        </div>
+                        <div className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-800">
+                            <DownloadIcon className="h-4 w-4" />
+                            Downloads
+                        </div>
+                    </nav>
+                </div>
+            </div>
+            <div className="flex flex-1 flex-col">
+                <div className="flex h-14 items-center justify-between border-b bg-gray-100 px-6 dark:border-gray-800 dark:bg-gray-900">
+                    <div className="flex items-center gap-4">
+                        <Select value={sortOption} onValueChange={setSortOption}>
+                            <SelectTrigger className="w-40">
+                                <SelectValue placeholder="Sort" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="date">Newest</SelectItem>
+                                <SelectItem value="name">Alphabetical</SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <div className="flex items-center gap-4">
+                        <Button variant="outline" size="sm" onClick={addReport}>
+                            <PlusIcon className="h-4 w-4 mr-2" />
+                            Create
+                        </Button>
+                    </div>
+                </div>
+                <div className="flex-1 overflow-auto p-4 md:p-6">
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+                        {sortedReports.map((rep, idx) => (
+                            <div
+                                key={rep.id}
+                                className="group relative rounded-md border border-gray-200 bg-white p-4 shadow-sm transition-all hover:border-gray-300 cursor-pointer"
+                                onClick={() => setSelectedId(rep.id)}
+                            >
+                                <button
+                                    onClick={(e) => handleDelete(rep.id, e)}
+                                    className="absolute left-2 top-2 text-gray-400 hover:text-red-600 opacity-0 group-hover:opacity-100"
+                                >
+                                    <X className="h-4 w-4" />
+                                </button>
+                                <div className="flex h-20 w-full items-center justify-center">
+                                    <FolderIcon className="h-12 w-12 text-gray-500 group-hover:text-gray-700" />
+                                </div>
+                                <div className="mt-4 text-center">
+                                    <h3 className="text-sm font-medium text-gray-900">{rep.name || `Report ${idx + 1}`}</h3>
+                                </div>
+                            </div>
+                        ))}
+                        <button
+                            onClick={addReport}
+                            className="flex flex-col items-center justify-center rounded-md border border-dashed border-gray-300 p-4 hover:border-gray-400"
+                        >
+                            <PlusIcon className="h-8 w-8 text-gray-500" />
+                            <span className="mt-2 text-sm">Add Report</span>
+                        </button>
+                    </div>
+                </div>
             </div>
         </div>
     )

--- a/src/features/report/components/user/Report.jsx
+++ b/src/features/report/components/user/Report.jsx
@@ -1,11 +1,13 @@
 import React, { useState } from "react"
 import { Button } from "@/components/ui/button"
-import { FolderIcon, PlusIcon } from "lucide-react"
+import { FolderIcon, PlusIcon, X } from "lucide-react"
 import InitialReportForm from "./InitialReportForm"
+import { useDeleteReportMutation } from "@/services/api"
 
 export default function Report() {
     const [reports, setReports] = useState([{ id: 0, name: "" }])
     const [selectedIndex, setSelectedIndex] = useState(null)
+    const [deleteReport] = useDeleteReportMutation()
 
     const addReport = () => {
         setReports((prev) => {
@@ -13,6 +15,16 @@ export default function Report() {
             return [...prev, newReport]
         })
         setSelectedIndex(reports.length)
+    }
+
+    const handleDelete = async (id, e) => {
+        e.stopPropagation()
+        try {
+            await deleteReport(id).unwrap()
+        } catch (err) {
+            console.error(err)
+        }
+        setReports((prev) => prev.filter((r) => r.id !== id))
     }
 
     const handleSubmit = (index, data) => {
@@ -43,6 +55,12 @@ export default function Report() {
                         className="group relative rounded-md border border-gray-200 bg-white p-4 shadow-sm transition-all hover:border-gray-300 cursor-pointer"
                         onClick={() => setSelectedIndex(idx)}
                     >
+                        <button
+                            onClick={(e) => handleDelete(rep.id, e)}
+                            className="absolute left-2 top-2 text-gray-400 hover:text-red-600 opacity-0 group-hover:opacity-100"
+                        >
+                            <X className="h-4 w-4" />
+                        </button>
                         <div className="flex h-20 items-center justify-center">
                             <FolderIcon className="h-12 w-12 text-gray-500 group-hover:text-gray-700" />
                         </div>

--- a/src/features/report/components/user/Report.jsx
+++ b/src/features/report/components/user/Report.jsx
@@ -1,22 +1,22 @@
 import React, { useState, useMemo } from "react"
 import { Button } from "@/components/ui/button"
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
 } from "@/components/ui/select"
 import {
-  FolderIcon,
-  HomeIcon,
-  FilesIcon,
-  ImagesIcon,
-  MusicIcon,
-  VideoIcon,
-  DownloadIcon,
-  PlusIcon,
-  X,
+    FolderIcon,
+    HomeIcon,
+    FilesIcon,
+    ImagesIcon,
+    MusicIcon,
+    VideoIcon,
+    DownloadIcon,
+    PlusIcon,
+    X,
 } from "lucide-react"
 import InitialReportForm from "./InitialReportForm"
 import { useDeleteReportMutation } from "@/services/api"
@@ -56,6 +56,7 @@ export default function Report() {
     }
 
     const handleSubmit = (id, data) => {
+        console.log("Submitting report:", id, data)
         setReports((prev) => prev.map((r) => (r.id === id ? { ...r, ...data } : r)))
         setSelectedId(null)
     }
@@ -88,40 +89,7 @@ export default function Report() {
 
     return (
         <div className="flex h-screen w-full">
-            <div className="hidden h-full w-64 shrink-0 border-r bg-gray-100 dark:border-gray-800 dark:bg-gray-900 lg:block">
-                <div className="flex h-full flex-col gap-4 p-4">
-                    <div className="flex items-center gap-2 font-semibold">
-                        <FolderIcon className="h-6 w-6" />
-                        <span>File Explorer</span>
-                    </div>
-                    <nav className="flex-1 space-y-2 overflow-auto">
-                        <div className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-800">
-                            <HomeIcon className="h-4 w-4" />
-                            Home
-                        </div>
-                        <div className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-800">
-                            <FilesIcon className="h-4 w-4" />
-                            Documents
-                        </div>
-                        <div className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-800">
-                            <ImagesIcon className="h-4 w-4" />
-                            Images
-                        </div>
-                        <div className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-800">
-                            <MusicIcon className="h-4 w-4" />
-                            Music
-                        </div>
-                        <div className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-800">
-                            <VideoIcon className="h-4 w-4" />
-                            Videos
-                        </div>
-                        <div className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-800">
-                            <DownloadIcon className="h-4 w-4" />
-                            Downloads
-                        </div>
-                    </nav>
-                </div>
-            </div>
+            
             <div className="flex flex-1 flex-col">
                 <div className="flex h-14 items-center justify-between border-b bg-gray-100 px-6 dark:border-gray-800 dark:bg-gray-900">
                     <div className="flex items-center gap-4">

--- a/src/features/report/components/user/Report.jsx
+++ b/src/features/report/components/user/Report.jsx
@@ -1,26 +1,65 @@
 import React, { useState } from "react"
 import { Button } from "@/components/ui/button"
+import { FolderIcon, PlusIcon } from "lucide-react"
 import InitialReportForm from "./InitialReportForm"
 
 export default function Report() {
     const [reports, setReports] = useState([{ id: 0 }])
+    const [selectedIndex, setSelectedIndex] = useState(null)
 
     const addReport = () => {
-        setReports((prev) => [...prev, { id: prev.length }])
+        setReports((prev) => {
+            const newReport = { id: prev.length }
+            return [...prev, newReport]
+        })
+        setSelectedIndex(reports.length)
     }
 
     const handleSubmit = (index, data) => {
-        console.log("submit report", index, data)
+        setReports((prev) => prev.map((r, i) => (i === index ? { ...r, data } : r)))
+        setSelectedIndex(null)
+    }
+
+    const handleBack = () => {
+        setSelectedIndex(null)
+    }
+
+    if (selectedIndex !== null) {
+        return (
+            <InitialReportForm
+                onSubmit={(data) => handleSubmit(selectedIndex, data)}
+                initialData={reports[selectedIndex].data || {}}
+                onBack={handleBack}
+            />
+        )
     }
 
     return (
-        <div className="space-y-6">
-            {reports.map((rep, idx) => (
-                <InitialReportForm key={rep.id} onSubmit={(data) => handleSubmit(idx, data)} />
-            ))}
-            <div className="flex justify-center">
-                <Button variant="outline" onClick={addReport}>Add Another Report</Button>
+        <div className="p-4 md:p-6">
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+                {reports.map((rep, idx) => (
+                    <div
+                        key={rep.id}
+                        className="group relative rounded-md border border-gray-200 bg-white p-4 shadow-sm transition-all hover:border-gray-300 cursor-pointer"
+                        onClick={() => setSelectedIndex(idx)}
+                    >
+                        <div className="flex h-20 items-center justify-center">
+                            <FolderIcon className="h-12 w-12 text-gray-500 group-hover:text-gray-700" />
+                        </div>
+                        <div className="mt-2 text-center">
+                            <span className="text-sm font-medium text-gray-900">Accident {idx + 1}</span>
+                        </div>
+                    </div>
+                ))}
+                <button
+                    onClick={addReport}
+                    className="flex flex-col items-center justify-center rounded-md border border-dashed border-gray-300 p-4 hover:border-gray-400"
+                >
+                    <PlusIcon className="h-8 w-8 text-gray-500" />
+                    <span className="mt-2 text-sm">Add Report</span>
+                </button>
             </div>
         </div>
     )
 }
+

--- a/src/features/report/components/user/Report.jsx
+++ b/src/features/report/components/user/Report.jsx
@@ -4,19 +4,19 @@ import { FolderIcon, PlusIcon } from "lucide-react"
 import InitialReportForm from "./InitialReportForm"
 
 export default function Report() {
-    const [reports, setReports] = useState([{ id: 0 }])
+    const [reports, setReports] = useState([{ id: 0, name: "" }])
     const [selectedIndex, setSelectedIndex] = useState(null)
 
     const addReport = () => {
         setReports((prev) => {
-            const newReport = { id: prev.length }
+            const newReport = { id: prev.length, name: "" }
             return [...prev, newReport]
         })
         setSelectedIndex(reports.length)
     }
 
     const handleSubmit = (index, data) => {
-        setReports((prev) => prev.map((r, i) => (i === index ? { ...r, data } : r)))
+        setReports((prev) => prev.map((r, i) => (i === index ? { ...r, ...data } : r)))
         setSelectedIndex(null)
     }
 
@@ -28,7 +28,7 @@ export default function Report() {
         return (
             <InitialReportForm
                 onSubmit={(data) => handleSubmit(selectedIndex, data)}
-                initialData={reports[selectedIndex].data || {}}
+                initialData={reports[selectedIndex]}
                 onBack={handleBack}
             />
         )
@@ -47,7 +47,7 @@ export default function Report() {
                             <FolderIcon className="h-12 w-12 text-gray-500 group-hover:text-gray-700" />
                         </div>
                         <div className="mt-2 text-center">
-                            <span className="text-sm font-medium text-gray-900">Accident {idx + 1}</span>
+                            <span className="text-sm font-medium text-gray-900">{rep.name || `Accident ${idx + 1}`}</span>
                         </div>
                     </div>
                 ))}

--- a/src/features/report/components/user/Report.jsx
+++ b/src/features/report/components/user/Report.jsx
@@ -13,7 +13,12 @@ import { useDeleteReportMutation } from "@/services/api"
 
 export default function Report() {
     const [reports, setReports] = useState([
-        { id: Date.now(), name: "", createdAt: new Date().toISOString() },
+        {
+            id: Date.now(),
+            name: "",
+            createdAt: new Date().toISOString(),
+            painEvaluations: [{ painMap: {}, formData: {} }],
+        },
     ])
     const [selectedId, setSelectedId] = useState(null)
     const [sortOption, setSortOption] = useState("date")
@@ -24,6 +29,7 @@ export default function Report() {
             id: Date.now(),
             name: "",
             createdAt: new Date().toISOString(),
+            painEvaluations: [{ painMap: {}, formData: {} }],
         }
         setReports((prev) => [...prev, newReport])
         setSelectedId(newReport.id)

--- a/src/features/report/components/user/Report.jsx
+++ b/src/features/report/components/user/Report.jsx
@@ -1,146 +1,26 @@
 import React, { useState } from "react"
-import {
-    Accordion,
-    AccordionItem,
-    AccordionTrigger
-} from "@/components/ui/accordion"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-
-import {
-    RenderQuesFuncs,
-    RenderTextAreaQues,
-    RenderRadioQues,
-    RenderCheckboxQues,
-    RenderOtherQues
-} from "@/utils/renderQuesFuncs"
-
-import PATIENT_INFO from "../../../../constants/initial-reports"
-import PainChartSection from "./HumanBody"
+import InitialReportForm from "./InitialReportForm"
 
 export default function Report() {
-    const [formData, setFormData] = useState({})
-    const [currentSectionIndex, setCurrentSectionIndex] = useState(0)
-    const [painMap, setPainMap] = useState({})
+    const [reports, setReports] = useState([{ id: 0 }])
 
-    const currentSection = PATIENT_INFO[currentSectionIndex]
-    const baseClasses = "border rounded-md p-4 space-y-4 mb-4 bg-white shadow-sm"
+    const addReport = () => {
+        setReports((prev) => [...prev, { id: prev.length }])
+    }
 
-    const renderQuestion = (question) => {
-        switch (question.type) {
-            case "group":
-                return (
-                    <RenderQuesFuncs
-                        key={question.id}
-                        question={question}
-                        formData={formData}
-                        setFormData={setFormData}
-                        commonFieldsetClasses={baseClasses}
-                    />
-                )
-            case "textarea":
-                return (
-                    <RenderTextAreaQues
-                        key={question.id}
-                        question={question}
-                        formData={formData}
-                        setFormData={setFormData}
-                        commonFieldsetClasses={baseClasses}
-                    />
-                )
-            case "radio":
-                return (
-                    <RenderRadioQues
-                        key={question.id}
-                        question={question}
-                        formData={formData}
-                        setFormData={setFormData}
-                        commonFieldsetClasses={baseClasses}
-                    />
-                )
-            case "checkbox":
-                return (
-                    <RenderCheckboxQues
-                        key={question.id}
-                        question={question}
-                        formData={formData}
-                        setFormData={setFormData}
-                        commonFieldsetClasses={baseClasses}
-                    />
-                )
-            case "other":
-                return (
-                    <RenderOtherQues
-                        key={question.id}
-                        question={question}
-                        formData={formData}
-                        setFormData={setFormData}
-                        commonFieldsetClasses={baseClasses}
-                    />
-                )
-            case "painChart":
-                return (
-                    <fieldset key={question.id} className={baseClasses}>
-                        <legend className="text-sm font-medium text-muted-foreground px-2">
-                            {question.label}
-                        </legend>
-                        <PainChartSection painMap={painMap} setPainMap={setPainMap} />
-                    </fieldset>
-                )
-            default:
-                return null
-        }
+    const handleSubmit = (index, data) => {
+        console.log("submit report", index, data)
     }
 
     return (
-        <form
-            onSubmit={(e) => {
-                e.preventDefault()
-                console.log(formData)
-            }}
-            className="flex flex-col md:flex-row flex-1 h-full overflow-hidden"
-        >
-            {/* Sidebar: visible only on md+ screens */}
-            <div className="hidden md:block md:w-80 border-r p-4 overflow-y-auto max-h-full">
-                <h2 className="text-lg font-semibold mb-4">Initial Reports</h2>
-                <Accordion
-                    type="single"
-                    collapsible
-                    className="space-y-2"
-                    value={currentSection.title}
-                >
-                    {PATIENT_INFO.map((section, idx) => (
-                        <AccordionItem
-                            key={section.id}
-                            value={section.title}
-                            onClick={() => setCurrentSectionIndex(idx)}
-                        >
-                            <AccordionTrigger>{section.title}</AccordionTrigger>
-                        </AccordionItem>
-                    ))}
-                </Accordion>
+        <div className="space-y-6">
+            {reports.map((rep, idx) => (
+                <InitialReportForm key={rep.id} onSubmit={(data) => handleSubmit(idx, data)} />
+            ))}
+            <div className="flex justify-center">
+                <Button variant="outline" onClick={addReport}>Add Another Report</Button>
             </div>
-
-            {/* Main form content */}
-            <div className="flex-1 p-4 md:p-6 overflow-y-auto h-full">
-                <Card>
-                    <CardHeader>
-                        <CardTitle>{currentSection.title}</CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-6">
-                        {currentSection.questions.map((q) => renderQuestion(q))}
-                        <div className="flex justify-end pt-4">
-                            {currentSectionIndex < PATIENT_INFO.length - 1 ? (
-                                <Button onClick={() => setCurrentSectionIndex((i) => i + 1)}>
-                                    Next
-                                </Button>
-                            ) : (
-                                <Button type="submit">Submit</Button>
-                            )}
-                        </div>
-                    </CardContent>
-                </Card>
-            </div>
-        </form>
+        </div>
     )
 }

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -40,7 +40,7 @@ export default function AppRoutes() {
             </Route>
 
             {/* User Dashboard */}
-            <Route path="/dashboard/:id" element={<ProtectRoute allowedRoles={['user']} />}>
+            <Route path="/dashboard/:id" element={<ProtectRoute allowedRoles={['patient']} />}>
                 <Route element={<HomePageLayout />}>
                     <Route index element={<HomePage />} />
                     <Route path="services/profile" element={<Profile />} />

--- a/src/routes/ProtectRoute.jsx
+++ b/src/routes/ProtectRoute.jsx
@@ -1,29 +1,34 @@
+import { useEffect } from 'react';
 import { useLocation, useNavigate, Outlet, Navigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
-import { useEffect } from 'react';
 
 export default function ProtectRoute({ allowedRoles }) {
     const navigate = useNavigate();
     const location = useLocation();
     const isAuthenticated = useSelector(state => state.data.auth.isAuthenticated);
-    const user = useSelector(state => state.data.auth.user);
+    const userID = useSelector(state => state.data.auth.userID);
+    const role = useSelector(state => state.data.auth.role);
 
-    const from = location.state?.from?.pathname || `/dashboard/${user?.id || ''}`;
-    console.log("user role:", user?.role);
+    // if you redirected here from /login, send them back to whatever they wanted
+    const from = location.state?.from?.pathname || `/dashboard/${userID || ''}`;
+
     useEffect(() => {
         if (isAuthenticated && location.pathname === '/login') {
             navigate(from, { replace: true });
         }
     }, [isAuthenticated, from, navigate, location.pathname]);
 
+    // not logged in → go to login
     if (!isAuthenticated) {
         return <Navigate to="/login" replace state={{ from: location }} />;
     }
 
-    if (allowedRoles && !allowedRoles.includes(user?.role)) {
-        console.warn(`Unauthorized access attempt by user with role: ${user?.role}`);
+    // if allowedRoles is provided AND the user's role isn't in it → unauthorized
+    if (allowedRoles?.length && !allowedRoles.includes(role)) {
+        console.warn(`Unauthorized access attempt by user with role: ${role}`);
         return <Navigate to="/unauthorized" replace />;
     }
 
+    // otherwise render the child route
     return <Outlet />;
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -4,7 +4,7 @@ import { setCredentials, logOut } from "../state/data/authSlice";
 // Base fetchBaseQuery configured to attach the access token and send HttpOnly refresh cookie
 const baseQuery = fetchBaseQuery({
     // Replace baseUrl with your API endpoint
-    baseUrl: "https://api.example.com",
+    baseUrl: "http://localhost:3000/v1/api/2025/",
     credentials: "include",
     prepareHeaders: (headers, { getState }) => {
         const token = getState().data?.auth?.accessToken;
@@ -22,7 +22,7 @@ const baseQueryWithReauth = async (args, api, extraOptions) => {
     if (result.error && result.error.status === 401) {
         // Attempt refresh
         const refreshResult = await baseQuery(
-            { url: "/refresh", method: "POST" },
+            { url: "auth/refresh", method: "POST" },
             api,
             extraOptions
         );
@@ -56,7 +56,7 @@ export const apiSlice = createApi({
         // LOGIN
         login: builder.mutation({
             query: (credentials) => ({
-                url: "/login",
+                url: "auth/login",
                 method: "POST",
                 body: credentials,
             }),
@@ -80,7 +80,7 @@ export const apiSlice = createApi({
         // REGISTER
         register: builder.mutation({
             query: (userData) => ({
-                url: "/signup",
+                url: "auth/signup",
                 method: "POST",
                 body: userData,
             }),
@@ -104,7 +104,7 @@ export const apiSlice = createApi({
         // MANUAL REFRESH (optional)
         refreshToken: builder.mutation({
             query: () => ({
-                url: "/refresh",
+                url: "auth/refresh",
                 method: "POST",
             }),
             async onQueryStarted(arg, { dispatch, queryFulfilled }) {
@@ -127,7 +127,7 @@ export const apiSlice = createApi({
         // LOGOUT
         logout: builder.mutation({
             query: (userId) => ({
-                url: "/logout",
+                url: "auth/logout",
                 method: "POST",
                 headers: {
                     "x-client-id": userId.toString(),
@@ -146,42 +146,42 @@ export const apiSlice = createApi({
         // REPORT SECTION SUBMISSIONS
         submitPatientIntake: builder.mutation({
             query: (data) => ({
-                url: "/reports/section1",
+                url: "/users/profile",
                 method: "POST",
                 body: data,
             }),
         }),
         submitAccidentDetails: builder.mutation({
             query: (data) => ({
-                url: "/reports/section2",
+                url: "/users/accdient-insurance",
                 method: "POST",
                 body: data,
             }),
         }),
         submitPainEvaluation: builder.mutation({
             query: (data) => ({
-                url: "/reports/section3",
+                url: "/users/pain-evaluation",
                 method: "POST",
                 body: data,
             }),
         }),
         submitSymptomDescription: builder.mutation({
             query: (data) => ({
-                url: "/reports/section4",
+                url: "/users/detailed-description",
                 method: "POST",
                 body: data,
             }),
         }),
         submitRecoveryImpact: builder.mutation({
             query: (data) => ({
-                url: "/reports/section5",
+                url: "/users/recovery-work-impact",
                 method: "POST",
                 body: data,
             }),
         }),
         submitHealthHistory: builder.mutation({
             query: (data) => ({
-                url: "/reports/section6",
+                url: "/users/health-history",
                 method: "POST",
                 body: data,
             }),
@@ -189,7 +189,7 @@ export const apiSlice = createApi({
 
         deleteReport: builder.mutation({
             query: (id) => ({
-                url: `/reports/${id}`,
+                url: `/users/${id}`,
                 method: "DELETE",
             }),
         }),

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -186,6 +186,13 @@ export const apiSlice = createApi({
                 body: data,
             }),
         }),
+
+        deleteReport: builder.mutation({
+            query: (id) => ({
+                url: `/reports/${id}`,
+                method: "DELETE",
+            }),
+        }),
     }),
 });
 
@@ -201,4 +208,5 @@ export const {
     useSubmitSymptomDescriptionMutation,
     useSubmitRecoveryImpactMutation,
     useSubmitHealthHistoryMutation,
+    useDeleteReportMutation,
 } = apiSlice;

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -142,6 +142,50 @@ export const apiSlice = createApi({
                 }
             },
         }),
+
+        // REPORT SECTION SUBMISSIONS
+        submitPatientIntake: builder.mutation({
+            query: (data) => ({
+                url: "/reports/section1",
+                method: "POST",
+                body: data,
+            }),
+        }),
+        submitAccidentDetails: builder.mutation({
+            query: (data) => ({
+                url: "/reports/section2",
+                method: "POST",
+                body: data,
+            }),
+        }),
+        submitPainEvaluation: builder.mutation({
+            query: (data) => ({
+                url: "/reports/section3",
+                method: "POST",
+                body: data,
+            }),
+        }),
+        submitSymptomDescription: builder.mutation({
+            query: (data) => ({
+                url: "/reports/section4",
+                method: "POST",
+                body: data,
+            }),
+        }),
+        submitRecoveryImpact: builder.mutation({
+            query: (data) => ({
+                url: "/reports/section5",
+                method: "POST",
+                body: data,
+            }),
+        }),
+        submitHealthHistory: builder.mutation({
+            query: (data) => ({
+                url: "/reports/section6",
+                method: "POST",
+                body: data,
+            }),
+        }),
     }),
 });
 
@@ -151,4 +195,10 @@ export const {
     useRegisterMutation,
     useRefreshTokenMutation,
     useLogoutMutation,
+    useSubmitPatientIntakeMutation,
+    useSubmitAccidentDetailsMutation,
+    useSubmitPainEvaluationMutation,
+    useSubmitSymptomDescriptionMutation,
+    useSubmitRecoveryImpactMutation,
+    useSubmitHealthHistoryMutation,
 } = apiSlice;

--- a/src/state/data/authSlice.js
+++ b/src/state/data/authSlice.js
@@ -1,7 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
-
+import { jwtDecode } from "jwt-decode";
 const initialState = {
-  user: null,
+  userID: null,
   accessToken: null,
   refreshToken: null,
   isAuthenticated: false,
@@ -16,7 +16,8 @@ const authSlice = createSlice({
   reducers: {
     setCredentials: (state, action) => {
       const { user, accessToken, refreshToken } = action.payload;
-      state.user = user;
+      const sub = user?.sub || jwtDecode(accessToken)?.sub || null;
+      state.userID = sub;
       state.accessToken = accessToken;
       state.refreshToken = refreshToken || null;
       state.role = user?.role || null;

--- a/src/state/data/entitiesSlice.js
+++ b/src/state/data/entitiesSlice.js
@@ -1,7 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
-  users: { byId: {}, allIds: [] },
+  user: { email: {}, allIds: [] },
   posts: { byId: {}, allIds: [] },
   comments: { byId: {}, allIds: [] },
 };

--- a/src/state/forms/accidentsInsurance.js
+++ b/src/state/forms/accidentsInsurance.js
@@ -1,0 +1,49 @@
+// src/features/accident/accidentSlice.js
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+    values: {
+        // Form fields
+        carType: "",
+        dateOfAccident: "",
+        timeOfAccident: "",
+        timePeriod: "AM",
+
+        accidentLocation: "",
+        howItOccurred: "",
+        circumstances: "",
+
+        awareOfAccident: null,
+        ambulanceOnScene: null,
+        airbagsDeployed: null,
+        seatbeltUsed: null,
+        policeOnScene: null,
+        pastAccidents: null,
+
+        lostTimeFromWork: null,
+        lostTimeDates: "",
+
+        insuranceCovered: null,
+        insuranceType: "",
+    },
+    errors: {}
+};
+
+const accidentSlice = createSlice({
+    name: "accident",
+    initialState,
+    reducers: {
+        setField: (state, action) => {
+            const { field, value } = action.payload;
+            state.values[field] = value;
+        },
+        resetForm: (state) => {
+            state.values = initialState.values;
+            state.errors = {};
+        }
+    }
+});
+
+// Exports
+export const { setField, resetForm } = accidentSlice.actions;
+export default accidentSlice.reducer;

--- a/src/state/forms/patientsIntakeFormSlice.js
+++ b/src/state/forms/patientsIntakeFormSlice.js
@@ -1,0 +1,53 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+    values: {
+        firstName: "",
+        lastName: "",
+        dayOfBirth: "",
+        monthOfBirth: "",
+        yearOfBirth: "",
+        gender: "",
+        mariedStatus: "",
+        race: "",
+        phoneNumber: "",
+        address: {
+            street: "",
+            city: "",
+            state: "",
+            zipCode: "",
+            homePHone: "",
+        },
+        employer: {
+            name: "",
+            occupation: "",
+
+        },
+        medicalHistory: {
+            allergies: "",
+            medications: "",
+            surgeries: ""
+        }
+    },
+    errors: {}
+};
+
+const patientsIntakeFormSlice = createSlice({
+    name: "patientsIntakeForm",
+    initialState,
+    reducers: {
+        updateField: (state, action) => {
+            const { field, value } = action.payload;
+            state.values[field] = value;
+        },
+        setErrors: (state, action) => {
+            state.errors = action.payload;
+        },
+        resetForm: (state) => {
+            state.values = initialState.values;
+            state.errors = {};
+        }
+    }
+});
+export const { updateField, setErrors, resetForm } = patientsIntakeFormSlice.actions;
+export default patientsIntakeFormSlice.reducer;

--- a/src/utils/renderQuesFuncs.jsx
+++ b/src/utils/renderQuesFuncs.jsx
@@ -39,7 +39,7 @@ export function RenderQuesFuncs({ question, formData, setFormData, commonFieldse
                         (field.id === "physicalWorkHours" && formData.physicalWork === "None") ||
                         (field.id === "exerciseHours" && formData.exercise === "None") ||
                         (["packsPerDay","smokingYears","beerPerWeek","liquorPerWeek","winePerWeek","alcoholYears"].includes(field.id) && formData.smokingStatus === "None") ||
-                        (["workTimes","workHoursPerDay","workDaysPerWeek","jobDescription"].includes(field.id) && (formData.currentlyWorking === "None" || formData.currentlyWorking === "NO"))
+                        (["workTimes","workHoursPerDay","workDaysPerWeek","jobDescription"].includes(field.id) && (formData.currentlyWorking === "none" || formData.currentlyWorking === "no"))
                     ) {
                         return null;
                     }

--- a/src/utils/renderQuesFuncs.jsx
+++ b/src/utils/renderQuesFuncs.jsx
@@ -38,7 +38,8 @@ export function RenderQuesFuncs({ question, formData, setFormData, commonFieldse
                         (field.id === "mentalWorkHours" && formData.mentalWork === "None") ||
                         (field.id === "physicalWorkHours" && formData.physicalWork === "None") ||
                         (field.id === "exerciseHours" && formData.exercise === "None") ||
-                        (["packsPerDay","smokingYears","beerPerWeek","liquorPerWeek","winePerWeek","alcoholYears"].includes(field.id) && formData.smokingStatus === "None") ||
+                        (["packsPerDay","smokingYears"].includes(field.id) && formData.smokingStatus === "None") ||
+                        (["beerPerWeek","liquorPerWeek","winePerWeek","alcoholYears"].includes(field.id) && (formData.drinkStatus === "none" || formData.drinkStatus === "no")) ||
                         (["workTimes","workHoursPerDay","workDaysPerWeek","jobDescription"].includes(field.id) && (formData.currentlyWorking === "none" || formData.currentlyWorking === "no"))
                     ) {
                         return null;

--- a/src/utils/renderQuesFuncs.jsx
+++ b/src/utils/renderQuesFuncs.jsx
@@ -38,9 +38,9 @@ export function RenderQuesFuncs({ question, formData, setFormData, commonFieldse
                         (field.id === "mentalWorkHours" && formData.mentalWork === "None") ||
                         (field.id === "physicalWorkHours" && formData.physicalWork === "None") ||
                         (field.id === "exerciseHours" && formData.exercise === "None") ||
-                        (["packsPerDay","smokingYears"].includes(field.id) && formData.smokingStatus === "None") ||
-                        (["beerPerWeek","liquorPerWeek","winePerWeek","alcoholYears"].includes(field.id) && (formData.drinkStatus === "none" || formData.drinkStatus === "no")) ||
-                        (["workTimes","workHoursPerDay","workDaysPerWeek","jobDescription"].includes(field.id) && (formData.currentlyWorking === "none" || formData.currentlyWorking === "no"))
+                        (["packsPerDay", "smokingYears"].includes(field.id) && formData.smokingStatus === "None") ||
+                        (["beerPerWeek", "liquorPerWeek", "winePerWeek", "alcoholYears"].includes(field.id) && (formData.drinkStatus === "none" || formData.drinkStatus === "no")) ||
+                        (["workTimes", "workHoursPerDay", "workDaysPerWeek", "jobDescription"].includes(field.id) && (formData.currentlyWorking === "none" || formData.currentlyWorking === "no"))
                     ) {
                         return null;
                     }

--- a/src/utils/renderQuesFuncs.jsx
+++ b/src/utils/renderQuesFuncs.jsx
@@ -8,7 +8,7 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Button } from "@/components/ui/button"
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 import { Calendar } from "@/components/ui/calendar"
-import { renderCalAge } from "./renderUtilsFunc"
+import { renderCalAge, renderDate } from "./renderUtilsFunc"
 
 export function FormatLegend({ question }) {
     return (
@@ -82,9 +82,30 @@ export function RenderQuesFuncs({ question, formData, setFormData, commonFieldse
                             ) : field.type === "date" ? (
                                 <Popover>
                                     <PopoverTrigger asChild>
-                                        <Button variant="outline" className="w-full justify-start">
-                                            {value ? value : `Select ${field.label}`}
-                                        </Button>
+                                        <Input
+                                            id={field.id}
+                                            placeholder="YYYY/MM/DD"
+                                            value={value}
+                                            onChange={(e) =>
+                                                setFormData((prev) => ({
+                                                    ...prev,
+                                                    [field.id]: e.target.value
+                                                }))
+                                            }
+                                            onBlur={(e) => {
+                                                const formatted = renderDate(e.target.value)
+                                                let extra = {}
+                                                if (formatted && field.id === "dob") {
+                                                    extra.age = renderCalAge(formatted.slice(0, 4))
+                                                }
+                                                setFormData((prev) => ({
+                                                    ...prev,
+                                                    [field.id]: formatted,
+                                                    ...extra
+                                                }))
+                                            }}
+                                            className="cursor-pointer"
+                                        />
                                     </PopoverTrigger>
                                     <PopoverContent className="w-auto p-0" align="start">
                                         <Calendar

--- a/src/utils/renderQuesFuncs.jsx
+++ b/src/utils/renderQuesFuncs.jsx
@@ -5,6 +5,7 @@ import { Label } from "@/components/ui/label"
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select"
 import { Input } from "@/components/ui/input"
 import { Checkbox } from "@/components/ui/checkbox"
+import { renderCalAge } from "./renderUtilsFunc"
 
 export function FormatLegend({ question }) {
     return (
@@ -72,6 +73,7 @@ export function RenderQuesFuncs({ question, formData, setFormData, commonFieldse
                                     value={value}
                                     onChange={(e) => {
                                         let val = e.target.value
+                                        let extra = {}
                                         if (field.type === "date" && val) {
                                             const d = new Date(val)
                                             if (!isNaN(d)) {
@@ -79,11 +81,15 @@ export function RenderQuesFuncs({ question, formData, setFormData, commonFieldse
                                                 const m = String(d.getMonth() + 1).padStart(2, "0")
                                                 const day = String(d.getDate()).padStart(2, "0")
                                                 val = `${y}/${m}/${day}`
+                                                if (field.id === "dob") {
+                                                    extra.age = renderCalAge(y)
+                                                }
                                             }
                                         }
                                         setFormData((prev) => ({
                                             ...prev,
-                                            [field.id]: val
+                                            [field.id]: val,
+                                            ...extra
                                         }))
                                     }}
                                 />

--- a/src/utils/renderQuesFuncs.jsx
+++ b/src/utils/renderQuesFuncs.jsx
@@ -68,14 +68,24 @@ export function RenderQuesFuncs({ question, formData, setFormData, commonFieldse
                             ) : (
                                 <Input
                                     id={field.id}
-                                    type={field.type === "number" ? "number" : "text"}
+                                    type={field.type === "number" ? "number" : field.type === "date" ? "date" : field.type === "tel" ? "tel" : "text"}
                                     value={value}
-                                    onChange={(e) =>
+                                    onChange={(e) => {
+                                        let val = e.target.value
+                                        if (field.type === "date" && val) {
+                                            const d = new Date(val)
+                                            if (!isNaN(d)) {
+                                                const y = d.getFullYear()
+                                                const m = String(d.getMonth() + 1).padStart(2, "0")
+                                                const day = String(d.getDate()).padStart(2, "0")
+                                                val = `${y}/${m}/${day}`
+                                            }
+                                        }
                                         setFormData((prev) => ({
                                             ...prev,
-                                            [field.id]: e.target.value
+                                            [field.id]: val
                                         }))
-                                    }
+                                    }}
                                 />
                             )}
                         </div>

--- a/src/utils/renderUtilsFunc.js
+++ b/src/utils/renderUtilsFunc.js
@@ -2,9 +2,12 @@
 
 export function renderDate(getDate) {
     if (!getDate) return ''
-    //    / or -
-    return String(getDate).replace(/\D/g, '')
-
+    const digits = String(getDate).replace(/\D/g, '')
+    if (digits.length !== 8) return String(getDate)
+    const y = digits.slice(0, 4)
+    const m = digits.slice(4, 6)
+    const d = digits.slice(6, 8)
+    return `${y}/${m}/${d}`
 }
 
 


### PR DESCRIPTION
## Summary
- create `InitialReportForm` component with validation for SSN, phone and date
- update `Report` page to support multiple initial reports
- improve `HumanBody` with lazy loaded body component and slider labels
- support `date` and `tel` input types and formatting

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba41cee3c832395f65d685e23fa3f